### PR TITLE
Tweaks

### DIFF
--- a/DupCaller/DupCallerCall.py
+++ b/DupCaller/DupCallerCall.py
@@ -150,6 +150,19 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    ## If the user points to an absolute output path, it will make a giant path under tmp/
+    ## Quick check if params["output"] starts is an absolute path pointing to the working directory, and changes it to a non-absolute path. 
+    ## Otherwise, keeps the large path.
+    cwd = os.getcwd()
+    if args.output.startswith(cwd):
+        abs_path = args.output
+        outpath = abs_path.replace(cwd, "")
+        ## Make sure we don't end up with a root path
+        if outpath.startswith("/"):
+            outpath = outpath[1:]
+    else:
+        outpath = args.output
+
     """
     Store Parameters
     """
@@ -158,7 +171,7 @@ if __name__ == "__main__":
         "normalBam": args.normalBam,
         "germline": args.germline,
         "reference": args.reference,
-        "output": args.output,
+        "output": outpath,
         "regions": args.regions,
         "threads": args.threads,
         "amperr": args.amperrs,
@@ -192,19 +205,7 @@ if __name__ == "__main__":
     # print("..............Loading reference genome.....................")
     # fasta = SeqIO.to_dict(SeqIO.parse(args.reference, "fasta"))
     startTime = time.time()
-    ## If the user points to an absolute output path, it will make a giant path under tmp/
-    ## Quick check if params["output"] starts with the working directory
-    cwd = os.getcwd()
-    if params["output"].startswith(cwd):
-        abs_path = params["output"]
-        outpath = abs_path.replace(cwd, "")
-        ## Make sure we don't end up with a root path
-        if outpath.startswith("/"):
-            outpath = outpath[1:]
-    else:
-        outpath = params["output"]
-
-    if not os.path.exists("tmp"):
+    if not os.path.exists(os.path.join("tmp", outpath)):
         try:
             os.makedirs(os.path.join("tmp", outpath))
         except OSError as e:
@@ -217,7 +218,6 @@ if __name__ == "__main__":
             if e.errno != errno.EEXIST:
                 raise 
     bamObject = getAlignmentObject(args.bam, args.reference)
-
     """
     Execulte variant calling
     """

--- a/DupCaller/DupCallerCall.py
+++ b/DupCaller/DupCallerCall.py
@@ -17,6 +17,7 @@ from pysam import AlignmentFile as BAM
 from DCutils.call import callBam
 from DCutils.funcs import createVcfStrings
 from DCutils.funcs import splitBamRegions
+from DCutils.funcs import getAlignmentObject
 
 if __name__ == "__main__":
     """
@@ -203,7 +204,7 @@ if __name__ == "__main__":
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise 
-    bamObject = BAM(args.bam, "rb")
+    bamObject = getAlignmentObject(args.bam, args.reference)
 
     """
     Execulte variant calling
@@ -426,7 +427,7 @@ if __name__ == "__main__":
         # subprocess.run(["rm"] + coverage_beds)
         # subprocess.run(["tabix",coverage_bed])
 
-    tBam = BAM(args.bam, "rb")
+    tBam = getAlignmentObject(args.bam, args.reference)
     contigs = tBam.references
     # print(contigs)
     chromDict = {contig: tBam.get_reference_length(contig) for contig in contigs}

--- a/DupCaller/DupCallerCall.py
+++ b/DupCaller/DupCallerCall.py
@@ -471,7 +471,7 @@ if __name__ == "__main__":
     pass_duprate = unique_read_num / pass_read_num
 
     with open(
-        args.output + "_duplex_group_stats.txt", "w"
+        outpath + "_duplex_group_stats.txt", "w"
     ) as f:
         f.write(
             "duplex_group_strand_composition\tduplex_group_number\t\
@@ -500,7 +500,7 @@ if __name__ == "__main__":
             )
 
     muts_by_group = np.loadtxt(
-        args.output + "_duplex_group_stats.txt",
+        outpath + "_duplex_group_stats.txt",
         skiprows=1,
         dtype=float,
         delimiter="\t",
@@ -539,7 +539,7 @@ if __name__ == "__main__":
     lgd2 = mpatches.Patch(color="blue", label="Naive")
     plt.legend(handles=[lgd1, lgd2])
     plt.savefig(
-        args.output + "_burden_by_duplex_group_size.png"
+        outpath + "_burden_by_duplex_group_size.png"
     )
     if len(FPAll + RPAll) != 0:
         FPs_count = [0 for _ in range(max(FPAll + RPAll))]
@@ -548,7 +548,7 @@ if __name__ == "__main__":
             FPs_count[nn] = FPAll.count(nn + 1)
             RPs_count[nn] = RPAll.count(nn + 1)
         with open(
-            args.output + "_SBS_end_profile.txt", "w"
+            outpath + "_SBS_end_profile.txt", "w"
         ) as f:
             f.write("Distance\tMutations_fragment_end\tMutations_read_end\n")
             for nn in range(max(FPAll + RPAll)):
@@ -571,7 +571,7 @@ if __name__ == "__main__":
         print(f"No mutations detected.")
         clonal_num = 0
 
-    with open(args.output + "_stats.txt", "w") as f:
+    with open(outpath + "_stats.txt", "w") as f:
         f.write(f"Number of Read Families\t{unique_read_num}\n")
         f.write(f"Number of Pass-filter Reads\t{pass_read_num}\n")
         f.write(f"Number of Effective Read Families\t{duplex_num}\n")
@@ -583,7 +583,7 @@ if __name__ == "__main__":
         )
         f.write(f"Efficiency\t{efficiency}\n")
 
-    with open(args.output + "_snv_burden.txt", "w") as f:
+    with open(outpath + "_snv_burden.txt", "w") as f:
         f.write(f"Number of Mutations\t{muts_num}\n")
         f.write(f"Number of multi-clonal Mutations\t{clonal_num}\n")
         f.write(f"Estimated Naive Burden\t{burden_naive}\n")
@@ -591,7 +591,7 @@ if __name__ == "__main__":
         f.write(f"Least-square Burden Upper 95% CI\t{burden_lstsq_uci}\n")
         f.write(f"Least-square Burden Lower 95% CI\t{burden_lstsq_lci}\n")
 
-    with open(args.output + "_indel_burden.txt", "w") as f:
+    with open(outpath + "_indel_burden.txt", "w") as f:
         f.write(f"Number of Mutations\t{indels_num}\n")
         f.write(f"Effective Coverage\t{coverage+coverage_indel}\n")
         f.write(f"Estimated Naive Burden\t{indel_burden}\n")

--- a/DupCaller/DupCallerLearn.py
+++ b/DupCaller/DupCallerLearn.py
@@ -12,6 +12,7 @@ from pysam import AlignmentFile as BAM
 from DCutils.call import callBam
 from DCutils.funcs import createVcfStrings
 from DCutils.splitBamRegions import splitBamRegions
+from DCutils.funcs import getAlignmentObject
 
 if __name__ == "__main__":
     """
@@ -164,7 +165,7 @@ if __name__ == "__main__":
     startTime = time.time()
     if not os.path.exists("tmp"):
         os.mkdir("tmp")
-    bamObject = BAM(args.bam, "rb")
+    bamObject = getAlignmentObject(args.bam, args.reference)
 
     """
     Execulte variant calling

--- a/src/DCutils/call.py
+++ b/src/DCutils/call.py
@@ -14,8 +14,8 @@ from Bio import SeqIO
 from DCutils.funcs import *
 
 
-def bamIterateMultipleRegion(bam, regions):
-    bamObject = BAM(bam, "rb")
+def bamIterateMultipleRegion(bam, regions, refpath):
+    bamObject = getAlignmentObject(bam, refpath=refpath)
     for region in regions:
         for rec in bamObject.fetch(*region):
             if len(region) >= 2:
@@ -29,6 +29,7 @@ def callBam(params, processNo, chunkSize):
     bam = params["tumorBam"]
     nbam = params["normalBam"]
     regions = params["regions"]
+    refpath = params["reference"]
     if params["germline"]:
         germline = VCF(params["germline"], "rb")
     else:
@@ -76,9 +77,9 @@ def callBam(params, processNo, chunkSize):
     total_coverage = 0
     total_coverage_indel = 0
     starttime = time.time()
-    tumorBam = BAM(bam, "rb")
+    tumorBam = getAlignmentObject(bam, refpath)
     if nbam:
-        normalBam = BAM(nbam, "rb")
+        normalBam = getAlignmentObject(nbam, refpath)
     else:
         normalBam = None
     currentReadSet = []
@@ -108,7 +109,7 @@ def callBam(params, processNo, chunkSize):
 
     print(f"Process {str(processNo)}: Initiated. Regions:{region_start}-{regions_end}")
     # for region in regions:
-    for rec, region in bamIterateMultipleRegion(bam, regions):
+    for rec, region in bamIterateMultipleRegion(bam, regions, refpath):
         recCount += 1
         if recCount == currentCheckPoint:
             currentTime = (time.time() - starttime) / 60

--- a/src/DCutils/funcs.py
+++ b/src/DCutils/funcs.py
@@ -9,13 +9,22 @@ from pysam import VariantFile as VCF
 from pysam import index as indexBam
 from scipy.stats import binom
 
+## Allow reading either bam or cram as bamObject
+def getAlignmentObject(bam, refpath=None):
+    if bam.endswith(".bam"):
+        bamObject = BAM(bam, "rb")
+    elif bam.endswith(".cram"):
+        bamObject=BAM(bam, "rc", reference_filename=refpath)
+    else:
+        raise NameError(f"{bam} should have .bam or .cram as file extension")
+    return(bamObject)
 
-def splitBamRegions(bam, num, contigs, fast=True):
+def splitBamRegions(bam, num, contigs, fast=True, refpath = None):
     if fast:
         # jobQueue = Queue()
         # jobLock = Lock()
         # resultQueue = Queue()
-        bamObject = BAM(bam, "rb")
+        bamObject = getAlignmentObject(bam, refpath)
         bamStats = bamObject.get_index_statistics()
         readNumber = 0
         contigCountsDict = {}
@@ -71,7 +80,7 @@ def splitBamRegions(bam, num, contigs, fast=True):
                 leftChunkSize = chunkSize
         return cutSite, chunkSize
     else:
-        bamObject = BAM(bam, "rb")
+        bamObject = getAlignmentObject(bam, refpath)
         bamStats = bamObject.get_index_statistics()
         readNumber = 0
         cutSites = [(0, 0)]


### PR DESCRIPTION
Hi Yuhe,

I noticed some unexpected behavior with the output files:

-  given `example/path` for the output arg, files would be written to `example/path/example/path`
-  Nested paths that were not created yet would throw errors, ie. it would error on the previous path but not `example/`
-  If output was an absolute path, the files under tmp/ would have a very very long path

Also, I thought try to add support for CRAM, since it seemed like a simple tweak (and I like cram), but pysam needs some info that isn't present in .crai files, so while the program can read a cram, it will still throw an error. I thought I'd keep the commits in the PR though since it doesn't interfere with bams as input.

Feel free to tweak/reject if you'd like!